### PR TITLE
Partial update to bevy 0.15.rc.3 + add hot-reloading + fix macos native

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [patch.crates-io]
-nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "more-bytemuck" }
 bevy_wasm_window_resize = { git = "https://github.com/Vrixyz/bevy_wasm_window_resize", rev = "770a679316ae24772d278360635e086278c70fa2" }
 bevy_editor_cam = { git = "https://github.com/Vrixyz/bevy_editor_cam", rev = "4dce484" }
 bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui", rev = "9edc10c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ resolver = "2"
 
 [workspace.dependencies]
 nalgebra = { version = "0.33", features = ["convert-bytemuck"] }
-wgpu = { version = "22.1", features = ["naga-ir"] }
+wgpu = { version = "23", features = ["naga-ir"] }
 bytemuck = { version = "1", features = ["derive"] }
 anyhow = "1"
 async-channel = "2"
-naga_oil = "0.15"
+naga_oil = "0.16"
 thiserror = "1"
 encase = { version = "0.10.0", features = ["nalgebra"] }
 
@@ -19,39 +19,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [patch.crates-io]
-bevy_wasm_window_resize = { git = "https://github.com/Vrixyz/bevy_wasm_window_resize", rev = "770a679316ae24772d278360635e086278c70fa2" }
-bevy_editor_cam = { git = "https://github.com/Vrixyz/bevy_editor_cam", rev = "4dce484" }
-bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui", rev = "9edc10c" }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_text = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_pbr = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_sprite = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_ui = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-# Optional
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_gizmos = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-# Dev
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-# Upstream update needed
-bevy_picking_core = { git = "https://github.com/vrixyz/bevy_mod_picking.git", branch = "bevy_main" }
-bevy_mod_picking = { git = "https://github.com/vrixyz/bevy_mod_picking.git", branch = "bevy_main" }
-# transitive dependencies
-bevy_hierarchy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_core = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_eventlistener = { git = "https://github.com/vrixyz/bevy_eventlistener.git", branch = "bevy_main" }
+bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui", branch = "bevy_main" }
 
 [profile.release]
 opt-level = 'z'

--- a/crates/wgsparkl-testbed2d/Cargo.toml
+++ b/crates/wgsparkl-testbed2d/Cargo.toml
@@ -31,9 +31,9 @@ futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
 async-std = { version = "1", features = ["attributes"] }
-bevy = { version = "0.15.0-dev", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"], git = "https://github.com/bevyengine/bevy", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_wasm_window_resize = "0.4"
-bevy_editor_cam = "0.3"
-bevy_mod_picking = { version = "0.20", default-features = false }
-bevy_egui = { version = "0.29", default-features = false, features = ["default_fonts", "render"] }
+bevy = { version = "0.15.0-rc.3", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"] }
+#bevy_wasm_window_resize = "0.4"
+#bevy_editor_cam = "0.3"
+#bevy_mod_picking = { version = "0.20", default-features = false }
+bevy_egui = { version = "0.30", default-features = false, features = ["default_fonts", "render"] }
 wgsparkl2d = { path = "../wgsparkl2d" }

--- a/crates/wgsparkl-testbed2d/Cargo.toml
+++ b/crates/wgsparkl-testbed2d/Cargo.toml
@@ -23,9 +23,9 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 async-channel = { workspace = true }
 
-wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore" }
-wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
-wgparry2d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
+wgcore = { version = "0.2", path = "../../../wgmath/crates/wgcore" }
+wgebra = { version = "0.2", path = "../../../wgmath/crates/wgebra" }
+wgparry2d = { version = "0.2", path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
 
 futures-test = "0.3"
 serial_test = "3"

--- a/crates/wgsparkl-testbed2d/Cargo.toml
+++ b/crates/wgsparkl-testbed2d/Cargo.toml
@@ -23,9 +23,9 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 async-channel = { workspace = true }
 
-wgcore = { path = "../../../wgmath/crates/wgcore" }
-wgebra = { path = "../../../wgmath/crates/wgebra" }
-wgparry2d = { path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
+wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore" }
+wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
+wgparry2d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
 
 futures-test = "0.3"
 serial_test = "3"

--- a/crates/wgsparkl-testbed3d/Cargo.toml
+++ b/crates/wgsparkl-testbed3d/Cargo.toml
@@ -23,9 +23,9 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 async-channel = { workspace = true }
 
-wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore" }
-wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
-wgparry3d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
+wgcore = { version = "0.2", path = "../../../wgmath/crates/wgcore" }
+wgebra = { version = "0.2", path = "../../../wgmath/crates/wgebra" }
+wgparry3d = { version = "0.2", path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
 
 futures-test = "0.3"
 serial_test = "3"

--- a/crates/wgsparkl-testbed3d/Cargo.toml
+++ b/crates/wgsparkl-testbed3d/Cargo.toml
@@ -31,9 +31,9 @@ futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
 async-std = { version = "1", features = ["attributes"] }
-bevy = { version = "0.15.0-dev", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"], git = "https://github.com/bevyengine/bevy", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
-bevy_editor_cam = "0.3"
-bevy_mod_picking = { version = "0.20", default-features = false }
-bevy_wasm_window_resize = "0.4"
-bevy_egui = { version = "0.29", default-features = false, features = ["default_fonts", "render"] }
+bevy = { version = "0.15.0-rc.3", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"] }
+#bevy_editor_cam = "0.3"
+#bevy_mod_picking = { version = "0.20", default-features = false }
+#bevy_wasm_window_resize = "0.4"
+bevy_egui = { version = "0.30", default-features = false, features = ["default_fonts", "render"] }
 wgsparkl3d = { path = "../wgsparkl3d" }

--- a/crates/wgsparkl-testbed3d/Cargo.toml
+++ b/crates/wgsparkl-testbed3d/Cargo.toml
@@ -23,9 +23,9 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 async-channel = { workspace = true }
 
-wgcore = { path = "../../../wgmath/crates/wgcore" }
-wgebra = { path = "../../../wgmath/crates/wgebra" }
-wgparry3d = { path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
+wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore" }
+wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
+wgparry3d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
 
 futures-test = "0.3"
 serial_test = "3"

--- a/crates/wgsparkl2d/Cargo.toml
+++ b/crates/wgsparkl2d/Cargo.toml
@@ -23,7 +23,7 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 encase = { workspace = true }
 
-wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore" }
+wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore", features = ["hot_reloading"] }
 wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
 wgparry2d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
 wgrapier2d = { version = "0.1", path = "../../../wgmath/crates/wgrapier/crates/wgrapier2d" }

--- a/crates/wgsparkl2d/Cargo.toml
+++ b/crates/wgsparkl2d/Cargo.toml
@@ -23,10 +23,10 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 encase = { workspace = true }
 
-wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore", features = ["hot_reloading"] }
-wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
-wgparry2d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
-wgrapier2d = { version = "0.1", path = "../../../wgmath/crates/wgrapier/crates/wgrapier2d" }
+wgcore = { version = "0.2", path = "../../../wgmath/crates/wgcore", features = ["hot_reloading"] }
+wgebra = { version = "0.2", path = "../../../wgmath/crates/wgebra" }
+wgparry2d = { version = "0.2", path = "../../../wgmath/crates/wgparry/crates/wgparry2d" }
+wgrapier2d = { version = "0.2", path = "../../../wgmath/crates/wgrapier/crates/wgrapier2d" }
 
 [dev-dependencies]
 nalgebra = { version = "0.33", features = ["rand"] }

--- a/crates/wgsparkl2d/Cargo.toml
+++ b/crates/wgsparkl2d/Cargo.toml
@@ -34,5 +34,5 @@ futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
 async-std = { version = "1", features = ["attributes"] }
-bevy = { version = "0.15.0-dev", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"], git = "https://github.com/bevyengine/bevy", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy = { version = "0.15.0-dev", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"] }
 wgsparkl_testbed2d = { path = "../wgsparkl-testbed2d" }

--- a/crates/wgsparkl3d/Cargo.toml
+++ b/crates/wgsparkl3d/Cargo.toml
@@ -34,5 +34,5 @@ futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
 async-std = { version = "1", features = ["attributes"] }
-bevy = { version = "0.15.0-dev", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"], git = "https://github.com/bevyengine/bevy", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy = { version = "0.15.0-rc.3", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"] }
 wgsparkl_testbed3d = { path = "../wgsparkl-testbed3d" }

--- a/crates/wgsparkl3d/Cargo.toml
+++ b/crates/wgsparkl3d/Cargo.toml
@@ -23,7 +23,7 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 encase = { workspace = true }
 
-wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore" }
+wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore", features = ["hot_reloading"] }
 wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
 wgparry3d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
 wgrapier3d = { version = "0.1", path = "../../../wgmath/crates/wgrapier/crates/wgrapier3d" }

--- a/crates/wgsparkl3d/Cargo.toml
+++ b/crates/wgsparkl3d/Cargo.toml
@@ -23,10 +23,10 @@ naga_oil = { workspace = true }
 bytemuck = { workspace = true }
 encase = { workspace = true }
 
-wgcore = { version = "0.1", path = "../../../wgmath/crates/wgcore", features = ["hot_reloading"] }
-wgebra = { version = "0.1", path = "../../../wgmath/crates/wgebra" }
-wgparry3d = { version = "0.1", path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
-wgrapier3d = { version = "0.1", path = "../../../wgmath/crates/wgrapier/crates/wgrapier3d" }
+wgcore = { version = "0.2", path = "../../../wgmath/crates/wgcore", features = ["hot_reloading"] }
+wgebra = { version = "0.2", path = "../../../wgmath/crates/wgebra" }
+wgparry3d = { version = "0.2", path = "../../../wgmath/crates/wgparry/crates/wgparry3d" }
+wgrapier3d = { version = "0.2", path = "../../../wgmath/crates/wgrapier/crates/wgrapier3d" }
 
 [dev-dependencies]
 nalgebra = { version = "0.33", features = ["rand"] }

--- a/src/grid/sort.rs
+++ b/src/grid/sort.rs
@@ -12,11 +12,36 @@ use wgpu::ComputePipeline;
     shader_defs = "dim_shader_defs"
 )]
 pub struct WgSort {
+    #[cfg(not(target_os = "macos"))]
     pub(crate) touch_particle_blocks: ComputePipeline,
     pub(crate) update_block_particle_count: ComputePipeline,
     pub(crate) copy_particles_len_to_scan_value: ComputePipeline,
     pub(crate) copy_scan_values_to_first_particles: ComputePipeline,
     pub(crate) finalize_particles_sort: ComputePipeline,
+}
+
+#[cfg(target_os = "macos")]
+pub struct TouchParticleBlocks {
+    pub(crate) touch_particle_blocks: ComputePipeline,
+}
+
+impl TouchParticleBlocks {
+    pub fn from_device(device: &wgpu::Device) -> Self {
+        #[cfg(feature = "dim2")]
+        let src = wgpu::include_wgsl!("touch_particle_blocks2d.wgsl");
+        #[cfg(feature = "dim3")]
+        let src = wgpu::include_wgsl!("touch_particle_blocks3d.wgsl");
+        let cs_module = device.create_shader_module(src);
+        let compute_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &cs_module,
+            entry_point: Some("touch_particle_blocks"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+        Self { touch_particle_blocks: compute_pipeline }
+    }
 }
 
 wgcore::test_shader_compilation!(WgSort);

--- a/src/grid/sort.wgsl
+++ b/src/grid/sort.wgsl
@@ -13,7 +13,10 @@ var<storage, read_write> sorted_particle_ids: array<u32>;
 @group(1) @binding(3)
 var<storage, read_write> particle_node_linked_lists: array<u32>;
 
-
+// Disable this kernel on macos because of the underlying compareExchangeMap which is
+// not working well with naga-oil. This is why we currently have the flattened
+// toouch_particle_block2/3d.wgsl shaders as a workaround currently.
+#if MACOS == 0
 @compute @workgroup_size(Grid::GRID_WORKGROUP_SIZE, 1, 1)
 fn touch_particle_blocks(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
     let id = invocation_id.x;
@@ -25,6 +28,7 @@ fn touch_particle_blocks(@builtin(global_invocation_id) invocation_id: vec3<u32>
         }
     }
 }
+#endif
 
 // TODO: can this kernel be combined with touch_particle_blocks?
 @compute @workgroup_size(Grid::GRID_WORKGROUP_SIZE, 1, 1)

--- a/src/grid/touch_particle_blocks2d.wgsl
+++ b/src/grid/touch_particle_blocks2d.wgsl
@@ -1,23 +1,9 @@
-#define_import_path wgsparkl::grid::grid
-#import wgsparkl::solver::params as Params;
-
-
 @group(0) @binding(0)
 var<storage, read_write> grid: Grid; // TODO: should be uniform? Currently it can’t due to the mutable num_active_blocks atomic.
 @group(0) @binding(1)
 var<storage, read_write> hmap_entries: array<GridHashMapEntry>;
 @group(0) @binding(2)
 var<storage, read_write> active_blocks: array<ActiveBlockHeader>;
-@group(0) @binding(3)
-var<storage, read_write> nodes: array<Node>;
-@group(0) @binding(4)
-var<uniform> sim_params: Params::SimulationParams;
-@group(0) @binding(5)
-var<storage, read_write> n_block_groups: DispatchIndirectArgs;
-@group(0) @binding(6)
-var<storage, read_write> nodes_linked_lists: array<NodeLinkedListAtomic>;
-@group(0) @binding(7)
-var<storage, read_write> n_g2p_p2g_groups: DispatchIndirectArgs;
 @group(0) @binding(8)
 var<storage, read_write> num_collisions: array<atomic<u32>>;
 
@@ -49,11 +35,7 @@ struct DispatchIndirectArgs {
  * Some index types.
  */
 struct BlockVirtualId {
-    #if DIM == 2
     id: vec2<i32>,
-    #else
-    id: vec3<i32>,
-    #endif
 }
 
 struct BlockHeaderId {
@@ -75,21 +57,10 @@ struct NodePhysicalId {
  */
 const NONE: u32 = 0xffffffffu;
 
-#if DIM == 2
 fn pack_key(key: BlockVirtualId) -> u32 {
     return (bitcast<u32>(key.id.x + 0x00007fff) & 0x0000ffffu) |
     ((bitcast<u32>(key.id.y + 0x00007fff) & 0x0000ffffu) << 16);
 }
-#else
-fn pack_key(key: BlockVirtualId) -> u32 {
-    // NOTE: we give the X and Z axis one more bit than Y.
-    //       This is assuming Y-up and the fact that we want
-    //       more room on the X-Z plane rather than along the up axis.
-    return (bitcast<u32>(key.id.x + 0x000003ff) & 0x000007ffu) |
-    ((bitcast<u32>(key.id.y + 0x000001ff) & 0x000003ffu) << 11) |
-    ((bitcast<u32>(key.id.z + 0x000003ff) & 0x000007ffu) << 21);
-}
-#endif
 
 fn hash(packed_key: u32) -> u32 {
     // Murmur3 hash function.
@@ -112,7 +83,6 @@ struct GridHashMapEntry {
     value: BlockHeaderId
 }
 
-#if MACOS == 0
 // The hash map ipmelementation is inspired from https://nosferalatu.com/SimpleGPUHashTable.html
 fn insertion_index(capacity: u32, key: BlockVirtualId) -> u32 {
     let packed_key = pack_key(key);
@@ -158,54 +128,11 @@ fn insertion_index(capacity: u32, key: BlockVirtualId) -> u32 {
 
     return NONE;
 }
-#endif
-
-fn find_block_header_id(key: BlockVirtualId) -> BlockHeaderId {
-    let packed_key = pack_key(key);
-    var slot = hash(packed_key) & (grid.hmap_capacity - 1);
-
-    loop {
-        let entry = &hmap_entries[slot];
-        let state = (*entry).state;
-        if state == packed_key {
-            return (*entry).value;
-        } else if state == NONE {
-            return BlockHeaderId(NONE);
-        }
-
-         slot = (slot + 1) & (grid.hmap_capacity - 1);
-    }
-
-    return BlockHeaderId(NONE);
-}
-
-@compute @workgroup_size(GRID_WORKGROUP_SIZE, 1, 1)
-fn reset_hmap(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
-    let id = invocation_id.x;
-    if id < grid.hmap_capacity {
-        hmap_entries[id].state = NONE;
-        // Resetting the following two isn’t necessary for correctness,
-        // but it makes debugging easier.
-        #if DIM == 2
-        hmap_entries[id].key = BlockVirtualId(vec2(0));
-        #else
-        hmap_entries[id].key = BlockVirtualId(vec3(0));
-        #endif
-        hmap_entries[id].value = BlockHeaderId(0);
-    }
-    if id == 0 {
-        grid.num_active_blocks = 0u;
-    }
-}
 
 /*
  * Sparse grid definition.
  */
-#if DIM == 2
 const NUM_ASSOC_BLOCKS: u32 = 4;
-#else
-const NUM_ASSOC_BLOCKS: u32 = 8;
-#endif
 const OFF_BY_ONE: i32 = 1;
 
 struct ActiveBlockHeader {
@@ -226,14 +153,9 @@ struct Grid {
 struct Node {
     /// The first three components contains either the cell’s momentum or its velocity
     /// (depending on the context). The fourth component contains the cell’s mass.
-    #if DIM == 2
     momentum_velocity_mass: vec3<f32>,
-    #else
-    momentum_velocity_mass: vec4<f32>,
-    #endif
 }
 
-#if DIM == 2
 fn block_associated_to_point(pt: vec2<f32>) -> BlockVirtualId {
     let assoc_cell = round(pt / grid.cell_width) - 1.0;
     let assoc_block = floor(assoc_cell / 8.0);
@@ -247,46 +169,16 @@ fn blocks_associated_to_point(pt: vec2<f32>) -> array<BlockVirtualId, NUM_ASSOC_
     let main_block = block_associated_to_point(pt);
     return blocks_associated_to_block(main_block);
 }
-#else
-fn block_associated_to_point(pt: vec3<f32>) -> BlockVirtualId {
-    let assoc_cell = round(pt / grid.cell_width) - 1.0;
-    let assoc_block = floor(assoc_cell / 4.0);
-    return BlockVirtualId(vec3(
-        i32(assoc_block.x),
-        i32(assoc_block.y),
-        i32(assoc_block.z),
-    ));
-}
-
-fn blocks_associated_to_point(pt: vec3<f32>) -> array<BlockVirtualId, NUM_ASSOC_BLOCKS> {
-    let main_block = block_associated_to_point(pt);
-    return blocks_associated_to_block(main_block);
-}
-#endif
 
 fn blocks_associated_to_block(block: BlockVirtualId) -> array<BlockVirtualId, NUM_ASSOC_BLOCKS> {
-    #if DIM == 2
     return array<BlockVirtualId, NUM_ASSOC_BLOCKS>(
         BlockVirtualId(block.id + vec2(0, 0)),
         BlockVirtualId(block.id + vec2(0, 1)),
         BlockVirtualId(block.id + vec2(1, 0)),
         BlockVirtualId(block.id + vec2(1, 1)),
     );
-    #else
-    return array<BlockVirtualId, NUM_ASSOC_BLOCKS>(
-        BlockVirtualId(block.id + vec3(0, 0, 0)),
-        BlockVirtualId(block.id + vec3(0, 0, 1)),
-        BlockVirtualId(block.id + vec3(0, 1, 0)),
-        BlockVirtualId(block.id + vec3(0, 1, 1)),
-        BlockVirtualId(block.id + vec3(1, 0, 0)),
-        BlockVirtualId(block.id + vec3(1, 0, 1)),
-        BlockVirtualId(block.id + vec3(1, 1, 0)),
-        BlockVirtualId(block.id + vec3(1, 1, 1)),
-    );
-    #endif
 }
 
-#if MACOS == 0
 fn mark_block_as_active(block: BlockVirtualId) {
     let slot = insertion_index(grid.hmap_capacity, block);
 
@@ -299,54 +191,28 @@ fn mark_block_as_active(block: BlockVirtualId) {
         hmap_entries[slot].value = BlockHeaderId(block_header_id);
     }
 }
-#endif
-
-fn block_header_id_to_physical_id(hid: BlockHeaderId) -> BlockPhysicalId {
-    return BlockPhysicalId(hid.id * NUM_CELL_PER_BLOCK);
-}
-
-#if DIM == 2
-fn node_id(pid: BlockPhysicalId, shift_in_block: vec2<u32>) -> NodePhysicalId {
-    return NodePhysicalId(pid.id + shift_in_block.x + shift_in_block.y * 8);
-}
-#else
-fn node_id(pid: BlockPhysicalId, shift_in_block: vec3<u32>) -> NodePhysicalId {
-    return NodePhysicalId(pid.id + shift_in_block.x + shift_in_block.y * 4 + shift_in_block.z * 4 * 4);
-}
-#endif
-
-fn div_ceil(x: u32, y: u32) -> u32 {
-    return (x + y - 1) / y;
-}
-
-@compute @workgroup_size(1)
-fn init_indirect_workgroups() {
-    let num_active_blocks = grid.num_active_blocks;
-    n_block_groups = DispatchIndirectArgs(div_ceil(num_active_blocks, GRID_WORKGROUP_SIZE), 1, 1);
-    n_g2p_p2g_groups = DispatchIndirectArgs(num_active_blocks, 1, 1);
-}
-
-@compute @workgroup_size(GRID_WORKGROUP_SIZE, 1, 1)
-fn reset(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
-   let num_threads = num_workgroups.x * GRID_WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
-   let i = invocation_id.x;
-   let num_nodes = grid.num_active_blocks * NUM_CELL_PER_BLOCK;
-   for (var i = invocation_id.x; i < num_nodes; i += num_threads) {
-       #if DIM == 2
-       nodes[i].momentum_velocity_mass = vec3(0.0);
-       #else
-       nodes[i].momentum_velocity_mass = vec4(0.0);
-       #endif
-       nodes_linked_lists[i].head = NONE;
-       nodes_linked_lists[i].len = 0u;
-   }
-}
 
 struct SimulationParameters {
     dt: f32,
-    #if DIM == 2
     gravity: vec2<f32>,
-    #else
-    gravity: vec3<f32>,
-    #endif
+}
+
+// ~~~~~~~~~~~ Copied from sort.wgsl and particle2/3d.wgsl ~~~~~~~~~~~~~
+struct Position {
+    pt: vec2<f32>,
+}
+
+@group(1) @binding(0)
+var<storage, read_write> particles_pos: array<Position>;
+
+@compute @workgroup_size(GRID_WORKGROUP_SIZE, 1, 1)
+fn touch_particle_blocks(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let id = invocation_id.x;
+    if id < arrayLength(&particles_pos) {
+        let particle = particles_pos[id];
+        var blocks = blocks_associated_to_point(particle.pt);
+        for (var i = 0u; i < NUM_ASSOC_BLOCKS; i += 1u) {
+            mark_block_as_active(blocks[i]);
+        }
+    }
 }

--- a/src/grid/touch_particle_blocks3d.wgsl
+++ b/src/grid/touch_particle_blocks3d.wgsl
@@ -1,23 +1,9 @@
-#define_import_path wgsparkl::grid::grid
-#import wgsparkl::solver::params as Params;
-
-
 @group(0) @binding(0)
 var<storage, read_write> grid: Grid; // TODO: should be uniform? Currently it can’t due to the mutable num_active_blocks atomic.
 @group(0) @binding(1)
 var<storage, read_write> hmap_entries: array<GridHashMapEntry>;
 @group(0) @binding(2)
 var<storage, read_write> active_blocks: array<ActiveBlockHeader>;
-@group(0) @binding(3)
-var<storage, read_write> nodes: array<Node>;
-@group(0) @binding(4)
-var<uniform> sim_params: Params::SimulationParams;
-@group(0) @binding(5)
-var<storage, read_write> n_block_groups: DispatchIndirectArgs;
-@group(0) @binding(6)
-var<storage, read_write> nodes_linked_lists: array<NodeLinkedListAtomic>;
-@group(0) @binding(7)
-var<storage, read_write> n_g2p_p2g_groups: DispatchIndirectArgs;
 @group(0) @binding(8)
 var<storage, read_write> num_collisions: array<atomic<u32>>;
 
@@ -49,11 +35,7 @@ struct DispatchIndirectArgs {
  * Some index types.
  */
 struct BlockVirtualId {
-    #if DIM == 2
-    id: vec2<i32>,
-    #else
     id: vec3<i32>,
-    #endif
 }
 
 struct BlockHeaderId {
@@ -75,12 +57,6 @@ struct NodePhysicalId {
  */
 const NONE: u32 = 0xffffffffu;
 
-#if DIM == 2
-fn pack_key(key: BlockVirtualId) -> u32 {
-    return (bitcast<u32>(key.id.x + 0x00007fff) & 0x0000ffffu) |
-    ((bitcast<u32>(key.id.y + 0x00007fff) & 0x0000ffffu) << 16);
-}
-#else
 fn pack_key(key: BlockVirtualId) -> u32 {
     // NOTE: we give the X and Z axis one more bit than Y.
     //       This is assuming Y-up and the fact that we want
@@ -89,7 +65,6 @@ fn pack_key(key: BlockVirtualId) -> u32 {
     ((bitcast<u32>(key.id.y + 0x000001ff) & 0x000003ffu) << 11) |
     ((bitcast<u32>(key.id.z + 0x000003ff) & 0x000007ffu) << 21);
 }
-#endif
 
 fn hash(packed_key: u32) -> u32 {
     // Murmur3 hash function.
@@ -112,7 +87,6 @@ struct GridHashMapEntry {
     value: BlockHeaderId
 }
 
-#if MACOS == 0
 // The hash map ipmelementation is inspired from https://nosferalatu.com/SimpleGPUHashTable.html
 fn insertion_index(capacity: u32, key: BlockVirtualId) -> u32 {
     let packed_key = pack_key(key);
@@ -158,54 +132,11 @@ fn insertion_index(capacity: u32, key: BlockVirtualId) -> u32 {
 
     return NONE;
 }
-#endif
-
-fn find_block_header_id(key: BlockVirtualId) -> BlockHeaderId {
-    let packed_key = pack_key(key);
-    var slot = hash(packed_key) & (grid.hmap_capacity - 1);
-
-    loop {
-        let entry = &hmap_entries[slot];
-        let state = (*entry).state;
-        if state == packed_key {
-            return (*entry).value;
-        } else if state == NONE {
-            return BlockHeaderId(NONE);
-        }
-
-         slot = (slot + 1) & (grid.hmap_capacity - 1);
-    }
-
-    return BlockHeaderId(NONE);
-}
-
-@compute @workgroup_size(GRID_WORKGROUP_SIZE, 1, 1)
-fn reset_hmap(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
-    let id = invocation_id.x;
-    if id < grid.hmap_capacity {
-        hmap_entries[id].state = NONE;
-        // Resetting the following two isn’t necessary for correctness,
-        // but it makes debugging easier.
-        #if DIM == 2
-        hmap_entries[id].key = BlockVirtualId(vec2(0));
-        #else
-        hmap_entries[id].key = BlockVirtualId(vec3(0));
-        #endif
-        hmap_entries[id].value = BlockHeaderId(0);
-    }
-    if id == 0 {
-        grid.num_active_blocks = 0u;
-    }
-}
 
 /*
  * Sparse grid definition.
  */
-#if DIM == 2
-const NUM_ASSOC_BLOCKS: u32 = 4;
-#else
 const NUM_ASSOC_BLOCKS: u32 = 8;
-#endif
 const OFF_BY_ONE: i32 = 1;
 
 struct ActiveBlockHeader {
@@ -226,28 +157,9 @@ struct Grid {
 struct Node {
     /// The first three components contains either the cell’s momentum or its velocity
     /// (depending on the context). The fourth component contains the cell’s mass.
-    #if DIM == 2
-    momentum_velocity_mass: vec3<f32>,
-    #else
     momentum_velocity_mass: vec4<f32>,
-    #endif
 }
 
-#if DIM == 2
-fn block_associated_to_point(pt: vec2<f32>) -> BlockVirtualId {
-    let assoc_cell = round(pt / grid.cell_width) - 1.0;
-    let assoc_block = floor(assoc_cell / 8.0);
-    return BlockVirtualId(vec2(
-        i32(assoc_block.x),
-        i32(assoc_block.y),
-    ));
-}
-
-fn blocks_associated_to_point(pt: vec2<f32>) -> array<BlockVirtualId, NUM_ASSOC_BLOCKS> {
-    let main_block = block_associated_to_point(pt);
-    return blocks_associated_to_block(main_block);
-}
-#else
 fn block_associated_to_point(pt: vec3<f32>) -> BlockVirtualId {
     let assoc_cell = round(pt / grid.cell_width) - 1.0;
     let assoc_block = floor(assoc_cell / 4.0);
@@ -262,17 +174,8 @@ fn blocks_associated_to_point(pt: vec3<f32>) -> array<BlockVirtualId, NUM_ASSOC_
     let main_block = block_associated_to_point(pt);
     return blocks_associated_to_block(main_block);
 }
-#endif
 
 fn blocks_associated_to_block(block: BlockVirtualId) -> array<BlockVirtualId, NUM_ASSOC_BLOCKS> {
-    #if DIM == 2
-    return array<BlockVirtualId, NUM_ASSOC_BLOCKS>(
-        BlockVirtualId(block.id + vec2(0, 0)),
-        BlockVirtualId(block.id + vec2(0, 1)),
-        BlockVirtualId(block.id + vec2(1, 0)),
-        BlockVirtualId(block.id + vec2(1, 1)),
-    );
-    #else
     return array<BlockVirtualId, NUM_ASSOC_BLOCKS>(
         BlockVirtualId(block.id + vec3(0, 0, 0)),
         BlockVirtualId(block.id + vec3(0, 0, 1)),
@@ -283,10 +186,8 @@ fn blocks_associated_to_block(block: BlockVirtualId) -> array<BlockVirtualId, NU
         BlockVirtualId(block.id + vec3(1, 1, 0)),
         BlockVirtualId(block.id + vec3(1, 1, 1)),
     );
-    #endif
 }
 
-#if MACOS == 0
 fn mark_block_as_active(block: BlockVirtualId) {
     let slot = insertion_index(grid.hmap_capacity, block);
 
@@ -299,54 +200,28 @@ fn mark_block_as_active(block: BlockVirtualId) {
         hmap_entries[slot].value = BlockHeaderId(block_header_id);
     }
 }
-#endif
-
-fn block_header_id_to_physical_id(hid: BlockHeaderId) -> BlockPhysicalId {
-    return BlockPhysicalId(hid.id * NUM_CELL_PER_BLOCK);
-}
-
-#if DIM == 2
-fn node_id(pid: BlockPhysicalId, shift_in_block: vec2<u32>) -> NodePhysicalId {
-    return NodePhysicalId(pid.id + shift_in_block.x + shift_in_block.y * 8);
-}
-#else
-fn node_id(pid: BlockPhysicalId, shift_in_block: vec3<u32>) -> NodePhysicalId {
-    return NodePhysicalId(pid.id + shift_in_block.x + shift_in_block.y * 4 + shift_in_block.z * 4 * 4);
-}
-#endif
-
-fn div_ceil(x: u32, y: u32) -> u32 {
-    return (x + y - 1) / y;
-}
-
-@compute @workgroup_size(1)
-fn init_indirect_workgroups() {
-    let num_active_blocks = grid.num_active_blocks;
-    n_block_groups = DispatchIndirectArgs(div_ceil(num_active_blocks, GRID_WORKGROUP_SIZE), 1, 1);
-    n_g2p_p2g_groups = DispatchIndirectArgs(num_active_blocks, 1, 1);
-}
-
-@compute @workgroup_size(GRID_WORKGROUP_SIZE, 1, 1)
-fn reset(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
-   let num_threads = num_workgroups.x * GRID_WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
-   let i = invocation_id.x;
-   let num_nodes = grid.num_active_blocks * NUM_CELL_PER_BLOCK;
-   for (var i = invocation_id.x; i < num_nodes; i += num_threads) {
-       #if DIM == 2
-       nodes[i].momentum_velocity_mass = vec3(0.0);
-       #else
-       nodes[i].momentum_velocity_mass = vec4(0.0);
-       #endif
-       nodes_linked_lists[i].head = NONE;
-       nodes_linked_lists[i].len = 0u;
-   }
-}
 
 struct SimulationParameters {
     dt: f32,
-    #if DIM == 2
-    gravity: vec2<f32>,
-    #else
     gravity: vec3<f32>,
-    #endif
+}
+
+// ~~~~~~~~~~~ Copied from sort.wgsl and particle2/3d.wgsl ~~~~~~~~~~~~~
+struct Position {
+    pt: vec3<f32>,
+}
+
+@group(1) @binding(0)
+var<storage, read_write> particles_pos: array<Position>;
+
+@compute @workgroup_size(GRID_WORKGROUP_SIZE, 1, 1)
+fn touch_particle_blocks(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let id = invocation_id.x;
+    if id < arrayLength(&particles_pos) {
+        let particle = particles_pos[id];
+        var blocks = blocks_associated_to_point(particle.pt);
+        for (var i = 0u; i < NUM_ASSOC_BLOCKS; i += 1u) {
+            mark_block_as_active(blocks[i]);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,12 @@ pub mod models;
 pub mod pipeline;
 pub mod solver;
 
-pub(crate) use wgparry::{dim_shader_defs, substitute_aliases};
+pub(crate) fn dim_shader_defs() -> HashMap<String, ShaderDefValue> {
+    let mut result = wgparry::dim_shader_defs();
+    result.insert("MACOS".to_string(), ShaderDefValue::Int(if cfg!(target_os = "macos") { 1 } else { 0 }));
+    result
+}
+
+use std::collections::HashMap;
+use naga_oil::compose::ShaderDefValue;
+pub(crate) use wgparry::{substitute_aliases};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -6,6 +6,8 @@ use crate::solver::{
     GpuParticles, GpuSimulationParams, Particle, SimulationParams, WgG2P, WgGridUpdate, WgP2G,
     WgParticleUpdate,
 };
+use naga_oil::compose::ComposerError;
+use wgcore::hot_reloading::HotReloadState;
 use wgcore::kernel::KernelInvocationQueue;
 use wgcore::Shader;
 use wgpu::Device;
@@ -20,6 +22,36 @@ pub struct MpmPipeline {
     particles_update: WgParticleUpdate,
     g2p: WgG2P,
     integrate_bodies: WgIntegrate,
+}
+
+impl MpmPipeline {
+    pub fn init_hot_reloading(&self, state: &mut HotReloadState) {
+        WgGrid::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgPrefixSum::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgSort::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgP2G::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgGridUpdate::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgParticleUpdate::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgG2P::watch_sources(state).unwrap(); // TODO: don’t unwrap
+        WgIntegrate::watch_sources(state).unwrap(); // TODO: don’t unwrap
+    }
+
+    pub fn reload_if_changed(
+        &mut self,
+        device: &Device,
+        state: &HotReloadState,
+    ) -> Result<bool, ComposerError> {
+        let mut changed = false;
+        changed = self.grid.reload_if_changed(device, state)? || changed;
+        changed = self.prefix_sum.reload_if_changed(device, state)? || changed;
+        changed = self.sort.reload_if_changed(device, state)? || changed;
+        changed = self.p2g.reload_if_changed(device, state)? || changed;
+        changed = self.grid_update.reload_if_changed(device, state)? || changed;
+        changed = self.particles_update.reload_if_changed(device, state)? || changed;
+        changed = self.g2p.reload_if_changed(device, state)? || changed;
+        changed = self.integrate_bodies.reload_if_changed(device, state)? || changed;
+        Ok(changed)
+    }
 }
 
 pub struct MpmData {
@@ -59,17 +91,17 @@ impl MpmData {
 }
 
 impl MpmPipeline {
-    pub fn new(device: &Device) -> Self {
-        Self {
-            grid: WgGrid::from_device(device),
-            prefix_sum: WgPrefixSum::from_device(device),
-            sort: WgSort::from_device(device),
-            p2g: WgP2G::from_device(device),
-            grid_update: WgGridUpdate::from_device(device),
-            particles_update: WgParticleUpdate::from_device(device),
-            g2p: WgG2P::from_device(device),
-            integrate_bodies: WgIntegrate::from_device(device),
-        }
+    pub fn new(device: &Device) -> Result<Self, ComposerError> {
+        Ok(Self {
+            grid: WgGrid::from_device(device)?,
+            prefix_sum: WgPrefixSum::from_device(device)?,
+            sort: WgSort::from_device(device)?,
+            p2g: WgP2G::from_device(device)?,
+            grid_update: WgGridUpdate::from_device(device)?,
+            particles_update: WgParticleUpdate::from_device(device)?,
+            g2p: WgG2P::from_device(device)?,
+            integrate_bodies: WgIntegrate::from_device(device)?,
+        })
     }
 
     pub fn queue_step<'a>(

--- a/src/solver/grid_update.wgsl
+++ b/src/solver/grid_update.wgsl
@@ -47,7 +47,6 @@ fn update_single_cell(cell_pos: vec2<f32>, momentum_velocity_mass: vec3<f32>) ->
     let mass = momentum_velocity_mass.z;
     let inv_mass = select(0.0, 1.0 / mass, mass > 0.0);
     var velocity = (momentum_velocity_mass.xy + mass * Grid::sim_params.gravity * Grid::sim_params.dt) * inv_mass;
-
     // Clamp the velocity so it doesn’t exceed 1 grid cell in one step.
     let vel_limit = vec2(Grid::grid.cell_width / Grid::sim_params.dt);
     velocity = clamp(velocity, -vel_limit, vel_limit);

--- a/src_testbed/hot_reload.rs
+++ b/src_testbed/hot_reload.rs
@@ -1,0 +1,19 @@
+use crate::AppState;
+use bevy::prelude::*;
+use bevy::render::renderer::RenderDevice;
+
+pub fn handle_hot_reloading(render_device: Res<RenderDevice>, mut state: ResMut<AppState>) {
+    let device = render_device.wgpu_device();
+    let state = &mut *state;
+    state.hot_reload.update_changes();
+    match state.pipeline.reload_if_changed(device, &state.hot_reload) {
+        Err(e) => {
+            println!("Failed to hot reload the MPM pipeline: {e}");
+        }
+        Ok(changed) => {
+            if changed {
+                println!("Hot reloaded MPM pipeline successfully.");
+            }
+        }
+    }
+}

--- a/src_testbed/instancing2d.rs
+++ b/src_testbed/instancing2d.rs
@@ -27,6 +27,7 @@ use bevy::{
 };
 use bytemuck::{Pod, Zeroable};
 use std::sync::Arc;
+use bevy::render::sync_world::MainEntity;
 
 pub const INSTANCING_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(3222377299100772450);
 
@@ -79,7 +80,7 @@ fn queue_custom(
     pipeline_cache: Res<PipelineCache>,
     meshes: Res<RenderAssets<RenderMesh>>,
     render_mesh_instances: Res<RenderMeshInstances>,
-    material_meshes: Query<Entity, With<InstanceMaterialData>>,
+    material_meshes: Query<(Entity, &MainEntity), With<InstanceMaterialData>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
     mut views: Query<(Entity, &ExtractedView, &Msaa)>,
 ) {
@@ -94,8 +95,8 @@ fn queue_custom(
 
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
-        for entity in &material_meshes {
-            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(entity) else {
+        for (entity, main_entity) in &material_meshes {
+            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*main_entity) else {
                 continue;
             };
             let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
@@ -107,7 +108,7 @@ fn queue_custom(
                 .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
                 .unwrap();
             transparent_phase.add(Transparent3d {
-                entity,
+                entity: (entity, *main_entity),
                 pipeline,
                 draw_function: draw_custom,
                 distance: rangefinder.distance_translation(&mesh_instance.translation),
@@ -223,7 +224,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
         // A borrow check workaround.
         let mesh_allocator = mesh_allocator.into_inner();
 
-        let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(item.entity())
+        let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(item.main_entity())
         else {
             return RenderCommandResult::Skip;
         };

--- a/src_testbed/instancing3d.rs
+++ b/src_testbed/instancing3d.rs
@@ -27,6 +27,7 @@ use bevy::{
 };
 use bytemuck::{Pod, Zeroable};
 use std::sync::Arc;
+use bevy::render::sync_world::MainEntity;
 
 pub const INSTANCING_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(3222377299100772450);
 
@@ -79,7 +80,7 @@ fn queue_custom(
     pipeline_cache: Res<PipelineCache>,
     meshes: Res<RenderAssets<RenderMesh>>,
     render_mesh_instances: Res<RenderMeshInstances>,
-    material_meshes: Query<Entity, With<InstanceMaterialData>>,
+    material_meshes: Query<(Entity, &MainEntity), With<InstanceMaterialData>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
     views: Query<(Entity, &ExtractedView, &Msaa)>,
 ) {
@@ -93,8 +94,8 @@ fn queue_custom(
         let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
-        for entity in &material_meshes {
-            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(entity) else {
+        for (entity, main_entity) in &material_meshes {
+            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*main_entity) else {
                 continue;
             };
             let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
@@ -106,7 +107,7 @@ fn queue_custom(
                 .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
                 .unwrap();
             transparent_phase.add(Transparent3d {
-                entity,
+                entity: (entity, *main_entity),
                 pipeline,
                 draw_function: draw_custom,
                 distance: rangefinder.distance_translation(&mesh_instance.translation),
@@ -222,7 +223,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
         // A borrow check workaround.
         let mesh_allocator = mesh_allocator.into_inner();
 
-        let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(item.entity())
+        let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(item.main_entity())
         else {
             return RenderCommandResult::Skip;
         };

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -13,6 +13,7 @@ pub mod instancing2d;
 #[cfg(feature = "dim3")]
 pub mod instancing3d;
 
+mod hot_reload;
 pub mod prep_vertex_buffer;
 pub mod startup;
 pub mod step;
@@ -23,9 +24,9 @@ use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
 use bevy_editor_cam::prelude::DefaultEditorCamPlugins;
 use bevy_wasm_window_resize::WindowResizePlugin;
-
 use instancing::INSTANCING_SHADER_HANDLE;
 use prep_vertex_buffer::{GpuRenderConfig, RenderConfig, WgPrepVertexBuffer};
+use wgcore::hot_reloading::HotReloadState;
 use wgcore::timestamps::GpuTimestamps;
 use wgsparkl::{
     pipeline::{MpmData, MpmPipeline},
@@ -43,7 +44,14 @@ pub fn init_testbed(app: &mut App) {
         .add_plugins(bevy_egui::EguiPlugin)
         .init_resource::<SceneInits>()
         .add_systems(Startup, startup::setup_app)
-        .add_systems(Update, (ui::update_ui, step::step_simulation));
+        .add_systems(
+            Update,
+            (
+                ui::update_ui,
+                step::step_simulation,
+                hot_reload::handle_hot_reloading,
+            ),
+        );
 
     #[cfg(feature = "dim2")]
     load_internal_asset!(
@@ -72,6 +80,7 @@ pub struct AppState {
     pub gravity_factor: f32,
     pub restarting: bool,
     pub selected_scene: usize,
+    pub hot_reload: HotReloadState,
 }
 
 #[derive(Resource)]

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -22,8 +22,8 @@ pub mod ui;
 use bevy::asset::load_internal_asset;
 use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
-use bevy_editor_cam::prelude::DefaultEditorCamPlugins;
-use bevy_wasm_window_resize::WindowResizePlugin;
+// use bevy_editor_cam::prelude::DefaultEditorCamPlugins;
+// use bevy_wasm_window_resize::WindowResizePlugin;
 use instancing::INSTANCING_SHADER_HANDLE;
 use prep_vertex_buffer::{GpuRenderConfig, RenderConfig, WgPrepVertexBuffer};
 use wgcore::hot_reloading::HotReloadState;
@@ -35,11 +35,11 @@ use wgsparkl::{
 
 pub fn init_testbed(app: &mut App) {
     app.add_plugins(DefaultPlugins)
-        .add_plugins(WindowResizePlugin)
-        .add_plugins((
-            bevy_mod_picking::DefaultPickingPlugins,
-            DefaultEditorCamPlugins,
-        ))
+        // .add_plugins(WindowResizePlugin)
+        // .add_plugins((
+        //     bevy_mod_picking::DefaultPickingPlugins,
+        //     DefaultEditorCamPlugins,
+        // ))
         .add_plugins(instancing::ParticlesMaterialPlugin)
         .add_plugins(bevy_egui::EguiPlugin)
         .init_resource::<SceneInits>()

--- a/src_testbed/startup.rs
+++ b/src_testbed/startup.rs
@@ -13,6 +13,7 @@ use bevy::render::renderer::RenderDevice;
 use bevy::render::view::NoFrustumCulling;
 use bevy_editor_cam::prelude::{EditorCam, EnabledMotion};
 use std::sync::Arc;
+use wgcore::hot_reloading::HotReloadState;
 use wgcore::tensor::GpuVector;
 use wgcore::timestamps::GpuTimestamps;
 use wgpu::Features;
@@ -24,7 +25,10 @@ pub fn setup_app(mut commands: Commands, device: Res<RenderDevice>) {
     let render_config = RenderConfig::new(RenderMode::Velocity);
     let gpu_render_config = GpuRenderConfig::new(device.wgpu_device(), render_config);
     let prep_vertex_buffer = WgPrepVertexBuffer::new(device.wgpu_device());
-    let pipeline = MpmPipeline::new(device.wgpu_device());
+
+    let mut hot_reload = HotReloadState::new().unwrap();
+    let pipeline = MpmPipeline::new(device.wgpu_device()).unwrap();
+    pipeline.init_hot_reloading(&mut hot_reload);
 
     commands.insert_resource(AppState {
         render_config,
@@ -36,6 +40,7 @@ pub fn setup_app(mut commands: Commands, device: Res<RenderDevice>) {
         gravity_factor: 1.0,
         restarting: false,
         selected_scene: 0,
+        hot_reload,
     });
 
     let (snd, rcv) = async_channel::unbounded();

--- a/src_testbed/startup.rs
+++ b/src_testbed/startup.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 use bevy::render::render_resource::BufferUsages;
 use bevy::render::renderer::RenderDevice;
 use bevy::render::view::NoFrustumCulling;
-use bevy_editor_cam::prelude::{EditorCam, EnabledMotion};
+// use bevy_editor_cam::prelude::{EditorCam, EnabledMotion};
 use std::sync::Arc;
 use wgcore::hot_reloading::HotReloadState;
 use wgcore::tensor::GpuVector;
@@ -73,14 +73,14 @@ pub fn setup_app(mut commands: Commands, device: Res<RenderDevice>) {
                 // }),
                 ..default()
             },
-            EditorCam {
-                enabled_motion: EnabledMotion {
-                    orbit: false,
-                    ..Default::default()
-                },
-                last_anchor_depth: -99.0,
-                ..Default::default()
-            },
+            // EditorCam {
+            //     enabled_motion: EnabledMotion {
+            //         orbit: false,
+            //         ..Default::default()
+            //     },
+            //     last_anchor_depth: -99.0,
+            //     ..Default::default()
+            // },
         ));
     }
 
@@ -91,8 +91,7 @@ pub fn setup_app(mut commands: Commands, device: Res<RenderDevice>) {
                 transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
                 ..default()
             },
-            EditorCam::default(),
-            // PanOrbitCamera::default(),
+            // EditorCam::default(),
         ));
     }
 }
@@ -149,7 +148,7 @@ pub fn setup_graphics(
 
     let num_instances = instances.len();
     commands.spawn((
-        cube,
+        Mesh3d(cube),
         SpatialBundle::INHERITED_IDENTITY,
         InstanceMaterialData {
             data: instances,


### PR DESCRIPTION
This PR adds hot-reloading (due to the update to wgcore 0.2), and starts updating the testbed to bevy 0.15.rc.3. Some of the bevy dependencies (like the camera) are currently not ported to 0.15.rc.3 and have been disabled for now.

This adds a workaround to make the examples work in MacOS native.