### PR TITLE
Add ghost particle advection.

### DIFF
--- a/crates/wgsparkl3d/Cargo.toml
+++ b/crates/wgsparkl3d/Cargo.toml
@@ -39,5 +39,9 @@ futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
 async-std = { version = "1", features = ["attributes"] }
-bevy = { version = "0.15.0", features = ["shader_format_glsl", "shader_format_spirv", "webgpu"] }
+bevy = { version = "0.15.0", features = [
+    "shader_format_glsl",
+    "shader_format_spirv",
+    "webgpu",
+] }
 wgsparkl_testbed3d = { path = "../wgsparkl-testbed3d" }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -44,7 +44,11 @@ impl GpuModels {
                 &plastic_states,
                 BufferUsages::STORAGE,
             ),
-            phases: GpuVector::init(device, &phases, BufferUsages::STORAGE),
+            phases: GpuVector::init(
+                device,
+                &phases,
+                BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+            ),
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -90,7 +90,7 @@ pub struct MpmData {
     pub impulses: GpuImpulses,
     pub poses_staging: GpuVector<GpuSim>,
     prefix_sum: PrefixSumWorkspace,
-    models: GpuModels,
+    pub models: GpuModels,
     coupling: Vec<BodyCouplingEntry>,
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -272,7 +272,6 @@ impl MpmPipeline {
                 &data.sim_params,
                 &data.grid,
                 &data.ghost_particles,
-                &data.particles,
                 &data.bodies,
             );
         }

--- a/src/solver/g2p_ghost.rs
+++ b/src/solver/g2p_ghost.rs
@@ -1,0 +1,77 @@
+use crate::grid::grid::{GpuGrid, WgGrid};
+use crate::grid::kernel::WgKernel;
+use crate::solver::params::{GpuSimulationParams, WgParams};
+use crate::solver::{GpuParticles, WgParticle};
+use crate::{dim_shader_defs, substitute_aliases};
+use nalgebra::Vector3;
+use wgcore::kernel::{KernelInvocationBuilder, KernelInvocationQueue};
+use wgcore::tensor::GpuVector;
+use wgcore::Shader;
+use wgpu::{BufferUsages, ComputePipeline, Device};
+use wgrapier::dynamics::{GpuBodySet, WgBody};
+
+pub struct GpuGhostParticles {
+    pub positions: GpuVector<Vector3<f32>>,
+}
+impl GpuGhostParticles {
+    pub fn empty(device: &Device) -> Self {
+        Self {
+            positions: GpuVector::uninit(device, 0, BufferUsages::STORAGE),
+        }
+    }
+    pub fn from_particles(device: &Device, particles: &[Vector3<f32>]) -> Self {
+        Self {
+            positions: GpuVector::encase(
+                device,
+                particles,
+                BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+            ),
+        }
+    }
+}
+
+#[derive(Shader)]
+#[shader(
+    derive(WgParams, WgParticle, WgGrid, WgKernel, WgBody),
+    src = "g2p_ghost.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs"
+)]
+pub struct WgG2PGhost {
+    pub g2p_ghost: ComputePipeline,
+}
+
+impl WgG2PGhost {
+    pub fn queue<'a>(
+        &'a self,
+        queue: &mut KernelInvocationQueue<'a>,
+        sim_params: &GpuSimulationParams,
+        grid: &GpuGrid,
+        ghost_particles: &GpuGhostParticles,
+        particles: &GpuParticles,
+        bodies: &GpuBodySet,
+    ) {
+        KernelInvocationBuilder::new(queue, &self.g2p_ghost)
+            .bind_at(
+                0,
+                [
+                    (grid.meta.buffer(), 0),
+                    (grid.hmap_entries.buffer(), 1),
+                    // (grid.active_blocks.buffer(), 2),
+                    (grid.nodes.buffer(), 3),
+                ],
+            )
+            .bind(
+                1,
+                [
+                    ghost_particles.positions.buffer(),
+                    sim_params.params.buffer(),
+                    // particles.positions.buffer(),
+                ],
+            )
+            // .bind(2, [bodies.vels().buffer(), bodies.mprops().buffer()])
+            .queue([ghost_particles.positions.len().div_ceil(64) as u32, 1, 1]);
+    }
+}
+
+wgcore::test_shader_compilation!(WgG2PGhost, wgcore, crate::dim_shader_defs());

--- a/src/solver/g2p_ghost.rs
+++ b/src/solver/g2p_ghost.rs
@@ -1,7 +1,7 @@
 use crate::grid::grid::{GpuGrid, WgGrid};
 use crate::grid::kernel::WgKernel;
 use crate::solver::params::{GpuSimulationParams, WgParams};
-use crate::solver::{GpuParticles, WgParticle};
+use crate::solver::WgParticle;
 use crate::{dim_shader_defs, substitute_aliases};
 use nalgebra::Vector3;
 use wgcore::kernel::{KernelInvocationBuilder, KernelInvocationQueue};
@@ -48,8 +48,7 @@ impl WgG2PGhost {
         sim_params: &GpuSimulationParams,
         grid: &GpuGrid,
         ghost_particles: &GpuGhostParticles,
-        particles: &GpuParticles,
-        bodies: &GpuBodySet,
+        _bodies: &GpuBodySet,
     ) {
         KernelInvocationBuilder::new(queue, &self.g2p_ghost)
             .bind_at(

--- a/src/solver/g2p_ghost.wgsl
+++ b/src/solver/g2p_ghost.wgsl
@@ -1,0 +1,173 @@
+#define_import_path wgsparkl::solver::g2p_ghost
+
+#import wgsparkl::solver::params as Params;
+#import wgsparkl::solver::particle as Particle;
+#import wgsparkl::grid::kernel as Kernel;
+#import wgsparkl::grid::grid as Grid;
+#import wgsparkl::models::linear_elasticity as ConstitutiveModel;
+#import wgsparkl::models::drucker_prager as DruckerPrager;
+#import wgrapier::body as Body;
+
+// TODO: Add particle_cdf as well.
+@group(1) @binding(0)
+var<storage, read_write> particles_pos: array<Particle::Position>;
+@group(1) @binding(1)
+var<uniform> params: Params::SimulationParams;
+@group(1) @binding(2)
+var<storage, read> orig_particles_pos: array<Particle::Position>;
+
+@group(2) @binding(0)
+var<storage, read> body_vels: array<Body::Velocity>;
+@group(2) @binding(1)
+var<storage, read> body_mprops: array<Body::MassProperties>;
+
+@compute @workgroup_size(64, 1, 1)
+fn g2p_ghost(
+    @builtin(global_invocation_id) dispatch_id: vec3<u32>,
+) {
+    let particle_id = dispatch_id.x;
+    if particle_id >= arrayLength(&particles_pos) {
+        return;
+    }
+
+    var NBH_SHIFTS = Kernel::NBH_SHIFTS;
+
+    // var rigid_vel = vec3<f32>(0.0);
+#if DIM == 2
+    var velocity = vec2<f32>(0.0);
+#else
+    var velocity = vec3<f32>(0.0);
+#endif
+
+    let particle_pos = particles_pos[particle_id];
+
+    let cell_width = Grid::grid.cell_width;
+    let dt = params.dt;
+
+    let inv_d = Kernel::inv_d(cell_width);
+    let ref_elt_pos_minus_particle_pos = Particle::dir_to_associated_grid_node(particle_pos, cell_width);
+    let w = Kernel::precompute_weights(ref_elt_pos_minus_particle_pos, cell_width);
+
+#if DIM == 2
+    let assoc_cell = vec2<i32>(round(particle_pos.pt / cell_width) - 1.0);
+#else
+    let assoc_cell = vec3<i32>(round(particle_pos.pt / cell_width) - 1.0);
+#endif
+
+    for (var i = 0u; i < Kernel::NBH_LEN; i += 1u) {
+        let shift = NBH_SHIFTS[i];
+#if DIM == 2
+        let cell = get_node(assoc_cell + vec2<i32>(shift));
+#else
+        let cell = get_node(assoc_cell + vec3<i32>(shift));
+#endif
+        let cell_data = cell.momentum_velocity_mass;
+        // let cell_cdf = cell.cdf;
+        // let is_compatible = Grid::affinities_are_compatible(particle_cdf.affinity, cell_cdf.affinities);
+
+#if DIM == 2
+        let dpt = ref_elt_pos_minus_particle_pos + vec2<f32>(shift) * cell_width;
+#else
+        let dpt = ref_elt_pos_minus_particle_pos + vec3<f32>(shift) * cell_width;
+#endif
+
+        var cpic_cell_data = cell_data;
+
+        // if !is_compatible {
+        //     if cell_cdf.closest_id != Grid::NONE {
+        //         let body_vel = body_vels[cell_cdf.closest_id]; // TODO: invalid if there is no body.
+        //         let body_com = body_mprops[cell_cdf.closest_id].com;
+        //         let cell_center = dpt + particle_pos.pt;
+        //         let body_pt_vel =  Body::velocity_at_point(body_com, body_vel, cell_center);
+        //         let particle_ghost_vel = body_pt_vel + Grid::project_velocity(particle_vel - body_pt_vel, particle_cdf.normal);
+        // 
+        //         cpic_cell_data = vec4(particle_ghost_vel, cell_data.w);
+        //     } else {
+        //         // If there is no adjacent collider, the ghost vel is the particle vel.
+        //         cpic_cell_data = vec4(particle_vel, cell_data.w);
+        //     }
+        // }
+
+#if DIM == 2
+        let weight = w.x[shift.x] * w.y[shift.y];
+        velocity += cpic_cell_data.xy * weight;
+#else
+        let weight = w.x[shift.x] * w.y[shift.y] * w.z[shift.z];
+        velocity += cpic_cell_data.xyz * weight;
+#endif
+        // velocity_gradient += (weight * inv_d) * outer_product(cpic_cell_data.xyz, dpt);
+    }
+
+    if length(velocity) > cell_width / dt {
+        velocity = velocity / length(velocity) * cell_width / dt;
+    }
+    particles_pos[particle_id].pt += velocity * dt;
+
+    // for (var i = 0u; i < 16u; i++) {
+    //     if Grid::affinity_bit(i, particle_cdf.affinity) {
+    //         let body_vel = body_vels[i];
+    //         let body_com = body_mprops[i].com;
+    //         rigid_vel += Body::velocity_at_point(body_com, body_vel, particle_pos.pt);
+    //     }
+    // }
+
+}
+
+#if DIM == 2
+fn get_node(pos: vec2<i32>) -> Grid::Node {
+    let offset = ((pos % 8) + 8) % 8;
+    let block_pos = (pos - offset) / 8;
+    let block_header = Grid::find_block_header_id(Grid::BlockVirtualId(block_pos));
+    if block_header.id != Grid::NONE {
+        let global_chunk_id = Grid::block_header_id_to_physical_id(block_header);
+        let global_node_id = Grid::node_id(global_chunk_id, vec2<u32>(offset));
+        return Grid::nodes[global_node_id.id];
+    } else {
+        return Grid::Node(vec3(0.0), Grid::NodeCdf(0.0, 0, Grid::NONE));
+    }
+}
+#else
+fn get_node(pos: vec3<i32>) -> Grid::Node {
+    let offset = ((pos % 4) + 4) % 4;
+    let block_pos = (pos - offset) / 4;
+    let block_header = Grid::find_block_header_id(Grid::BlockVirtualId(block_pos));
+    if block_header.id != Grid::NONE {
+        let global_chunk_id = Grid::block_header_id_to_physical_id(block_header);
+        let global_node_id = Grid::node_id(global_chunk_id, vec3<u32>(offset));
+        return Grid::nodes[global_node_id.id];
+    } else {
+        return Grid::Node(vec4(0.0), Grid::NodeCdf(0.0, 0, Grid::NONE));
+    }
+}
+#endif
+
+// TODO: upstream to wgebra?
+#if DIM == 2
+fn outer_product(a: vec2<f32>, b: vec2<f32>) -> mat2x2<f32> {
+    return mat2x2(
+        a * b.x,
+        a * b.y,
+    );
+}
+
+// Note that this is different from p2g. We don’t need to shift the index since the truncated
+// blocks (the neighbor blocks) are in the quadrants with larger indices.
+fn flatten_shared_index(x: u32, y: u32) -> u32 {
+    return x + y * 10;
+}
+#else
+fn outer_product(a: vec3<f32>, b: vec3<f32>) -> mat3x3<f32> {
+    return mat3x3(
+        a * b.x,
+        a * b.y,
+        a * b.z,
+    );
+}
+
+
+// Note that this is different from p2g. We don’t need to shift the index since the truncated
+// blocks (the neighbor blocks) are in the octants with larger indices.
+fn flatten_shared_index(x: u32, y: u32, z: u32) -> u32 {
+    return x + y * 6 + z * 6 * 6;
+}
+#endif

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,5 +1,6 @@
 pub use g2p::WgG2P;
 pub use g2p_cdf::WgG2PCdf;
+pub use g2p_ghost::{GpuGhostParticles, WgG2PGhost};
 pub use p2g::WgP2G;
 pub use p2g_cdf::WgP2GCdf;
 pub use params::{GpuSimulationParams, SimulationParams, WgParams};
@@ -16,6 +17,7 @@ pub use rigid_particle_update::WgRigidParticleUpdate;
 
 mod g2p;
 mod g2p_cdf;
+mod g2p_ghost;
 mod p2g;
 mod p2g_cdf;
 mod params;

--- a/src/solver/particle2d.wgsl
+++ b/src/solver/particle2d.wgsl
@@ -32,6 +32,11 @@ struct Cdf {
 //    closest_id: u32,
 }
 
+struct Phase {
+    phase: f32,
+    max_stretch: f32,
+}
+
 fn default_cdf() -> Cdf {
     return Cdf(vec2(0.0), vec2(0.0), 0.0, 0);
 }

--- a/src/solver/particle3d.rs
+++ b/src/solver/particle3d.rs
@@ -199,7 +199,11 @@ impl GpuParticles {
                 &positions,
                 BufferUsages::STORAGE | BufferUsages::COPY_SRC,
             ),
-            dynamics: GpuVector::encase(device, &dynamics, BufferUsages::STORAGE),
+            dynamics: GpuVector::encase(
+                device,
+                &dynamics,
+                BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+            ),
             sorted_ids: GpuVector::uninit(device, particles.len() as u32, BufferUsages::STORAGE),
             node_linked_lists: GpuVector::uninit(
                 device,

--- a/src/solver/particle3d.wgsl
+++ b/src/solver/particle3d.wgsl
@@ -29,6 +29,10 @@ struct RigidParticleIndices {
     collider: u32,
 }
 
+struct Phase {
+    phase: f32,
+    max_stretch: f32,
+}
 
 fn default_cdf() -> Cdf {
     return Cdf(vec3(0.0), vec3(0.0), 0.0, 0);

--- a/src/solver/particle_update.wgsl
+++ b/src/solver/particle_update.wgsl
@@ -28,7 +28,7 @@ var<storage, read> plasticity: array<DruckerPrager::Plasticity>;
 @group(1) @binding(4)
 var<storage, read_write> plastic_state: array<DruckerPrager::PlasticState>;
 @group(1) @binding(5)
-var<storage, read_write> phases: array<Phase>;
+var<storage, read_write> phases: array<Particle::Phase>;
 @group(1) @binding(6)
 var<uniform> params: Params::SimulationParams;
 
@@ -36,11 +36,6 @@ var<uniform> params: Params::SimulationParams;
 var<storage, read> collision_shapes: array<Cuboid::Cuboid>;
 @group(2) @binding(1)
 var<storage, read> collision_shape_poses: array<Transform>;
-
-struct Phase {
-    phase: f32,
-    max_stretch: f32,
-}
 
 @compute @workgroup_size(64, 1, 1)
 fn main(

--- a/src_testbed/instancing3d.rs
+++ b/src_testbed/instancing3d.rs
@@ -159,7 +159,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
             // NOTE: shader locations 0-2 are taken up by Position, Normal and UV attributes.
             attributes: vec![
                 VertexAttribute {
-                    format: VertexFormat::Float32x4,
+                    format: VertexFormat::Float32x3,
                     offset: 0,
                     shader_location: 3,
                 },

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -49,11 +49,18 @@ use wgsparkl::{
 #[derive(Debug, Clone)]
 pub struct TestbedSettings {
     pub draw_particles: bool,
+    pub wireframe: bool,
+    /// So apparently, marking with `#[non_exhastive]` prevents struct update syntax from working.
+    /// And using `..default()` results in a warning if all of the fields are specified (even if some may be added later)
+    /// so we have this field suppress that.
+    pub _indication_other_fields_may_be_added_later_so_use_default: (),
 }
 impl Default for TestbedSettings {
     fn default() -> Self {
         Self {
             draw_particles: true,
+            wireframe: true,
+            _indication_other_fields_may_be_added_later_so_use_default: (),
         }
     }
 }
@@ -82,8 +89,10 @@ pub fn init_testbed_with_settings(app: &mut App, settings: TestbedSettings) {
                 .chain(),
         );
 
-    #[cfg(not(target_arch = "wasm32"))]
-    app.add_plugins(WireframePlugin);
+    if settings.wireframe {
+        #[cfg(not(target_arch = "wasm32"))]
+        app.add_plugins(WireframePlugin);
+    }
 
     #[cfg(feature = "dim2")]
     load_internal_asset!(

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -46,15 +46,29 @@ use wgsparkl::{
     solver::Particle,
 };
 
-pub fn init_testbed(app: &mut App) {
+#[derive(Debug, Clone)]
+pub struct TestbedSettings {
+    pub draw_particles: bool,
+}
+impl Default for TestbedSettings {
+    fn default() -> Self {
+        Self {
+            draw_particles: true,
+        }
+    }
+}
+
+pub fn init_testbed_with_settings(app: &mut App, settings: TestbedSettings) {
     app.add_plugins(DefaultPlugins)
         // .add_plugins(WindowResizePlugin)
         .add_plugins((
             // bevy_mod_picking::DefaultPickingPlugins,
             DefaultEditorCamPlugins,
-        ))
-        .add_plugins(instancing::ParticlesMaterialPlugin)
-        .add_plugins(bevy_egui::EguiPlugin)
+        ));
+    if settings.draw_particles {
+        app.add_plugins(instancing::ParticlesMaterialPlugin);
+    }
+    app.add_plugins(bevy_egui::EguiPlugin)
         .init_resource::<SceneInits>()
         .add_systems(Startup, startup::setup_app)
         .add_systems(
@@ -85,6 +99,10 @@ pub fn init_testbed(app: &mut App) {
         "./instancing3d.wgsl",
         Shader::from_wgsl
     );
+}
+
+pub fn init_testbed(app: &mut App) {
+    init_testbed_with_settings(app, default())
 }
 
 #[derive(Resource)]

--- a/src_testbed/prep_vertex_buffer.rs
+++ b/src_testbed/prep_vertex_buffer.rs
@@ -5,6 +5,7 @@ use wgebra::WgSvd2;
 use wgebra::WgSvd3;
 use wgpu::{Buffer, BufferUsages, ComputePipeline, Device};
 use wgsparkl::grid::grid::{GpuGrid, WgGrid};
+use wgsparkl::models::GpuModels;
 use wgsparkl::solver::{GpuParticles, GpuSimulationParams};
 use wgsparkl::solver::{GpuRigidParticles, WgParticle};
 
@@ -15,6 +16,7 @@ pub enum RenderMode {
     CdfNormals = 3,
     CdfDistances = 4,
     CdfSigns = 5,
+    Phase = 6,
 }
 
 impl RenderMode {
@@ -26,6 +28,7 @@ impl RenderMode {
             Self::CdfNormals => "cdf (normals)",
             Self::CdfDistances => "cdf (distances)",
             Self::CdfSigns => "cdf (signs)",
+            Self::Phase => "phase",
         }
     }
 
@@ -37,6 +40,7 @@ impl RenderMode {
             3 => Self::CdfNormals,
             4 => Self::CdfDistances,
             5 => Self::CdfSigns,
+            6 => Self::Phase,
             _ => unreachable!(),
         }
     }
@@ -85,6 +89,7 @@ impl WgPrepVertexBuffer {
         queue: &mut KernelInvocationQueue<'a>,
         config: &GpuRenderConfig,
         particles: &GpuParticles,
+        models: &GpuModels,
         rigid_particles: &GpuRigidParticles,
         grid: &GpuGrid,
         params: &GpuSimulationParams,
@@ -99,6 +104,7 @@ impl WgPrepVertexBuffer {
                 grid.meta.buffer(),
                 params.params.buffer(),
                 config.buffer.buffer(),
+                models.phases.buffer(),
             ])
             .queue(particles.positions.len().div_ceil(64) as u32);
 

--- a/src_testbed/prep_vertex_buffer2d.wgsl
+++ b/src_testbed/prep_vertex_buffer2d.wgsl
@@ -17,6 +17,13 @@ var<storage, read_write> grid: Grid::Grid;
 var<uniform> params: Params::SimulationParams;
 @group(0) @binding(5)
 var<storage, read> config: RenderConfig;
+@group(0) @binding(6)
+var<storage, read> phases: array<Phase>;
+
+struct Phase {
+    phase: f32,
+    max_stretch: f32,
+}
 
 struct RenderConfig {
     mode: u32,
@@ -28,6 +35,7 @@ const VELOCITY: u32 = 2;
 const CDF_NORMALS: u32 = 3;
 const CDF_DISTANCES: u32 = 4;
 const CDF_SIGNS: u32 = 5;
+const PHASE: u32 = 6;
 
 struct InstanceData {
     deformation: mat3x3<f32>,
@@ -77,16 +85,19 @@ fn main(
                 instances[particle_id].color = vec4(abs(d), 0.0, 0.0, color.w);
             }
         } else if config.mode == CDF_SIGNS {
-             let d = particles_dyn[particle_id].cdf.affinity;
-             let a = (d >> 16) & (d & 0x0000ffff);
-             if d == 0 {
-                 instances[particle_id].color = vec4(0.0, 0.0, 0.0, color.w);
-             } else if a == 0 {
-                 instances[particle_id].color = vec4(0.0, 1.0, 0.0, color.w);
-             } else {
-                 instances[particle_id].color = vec4(1.0, 0.0, 0.0, color.w);
-             }
-         }
+            let d = particles_dyn[particle_id].cdf.affinity;
+            let a = (d >> 16) & (d & 0x0000ffff);
+            if d == 0 {
+                instances[particle_id].color = vec4(0.0, 0.0, 0.0, color.w);
+            } else if a == 0 {
+                instances[particle_id].color = vec4(0.0, 1.0, 0.0, color.w);
+            } else {
+                instances[particle_id].color = vec4(1.0, 0.0, 0.0, color.w);
+            }
+        } else if config.mode == PHASE {
+            let phase = phases[particle_id].phase;
+            instances[particle_id].color = vec4(vec3(mix(0.1, 1.0, phase)), color.w);
+        }
     }
 }
 

--- a/src_testbed/prep_vertex_buffer2d.wgsl
+++ b/src_testbed/prep_vertex_buffer2d.wgsl
@@ -18,12 +18,7 @@ var<uniform> params: Params::SimulationParams;
 @group(0) @binding(5)
 var<storage, read> config: RenderConfig;
 @group(0) @binding(6)
-var<storage, read> phases: array<Phase>;
-
-struct Phase {
-    phase: f32,
-    max_stretch: f32,
-}
+var<storage, read> phases: array<Particle::Phase>;
 
 struct RenderConfig {
     mode: u32,

--- a/src_testbed/prep_vertex_buffer3d.wgsl
+++ b/src_testbed/prep_vertex_buffer3d.wgsl
@@ -18,12 +18,7 @@ var<uniform> params: Params::SimulationParams;
 @group(0) @binding(5)
 var<storage, read> config: RenderConfig;
 @group(0) @binding(6)
-var<storage, read> phases: array<Phase>;
-
-struct Phase {
-    phase: f32,
-    max_stretch: f32,
-}
+var<storage, read> phases: array<Particle::Phase>;
 
 struct RenderConfig {
     mode: u32,

--- a/src_testbed/prep_vertex_buffer3d.wgsl
+++ b/src_testbed/prep_vertex_buffer3d.wgsl
@@ -17,6 +17,13 @@ var<storage, read_write> grid: Grid::Grid;
 var<uniform> params: Params::SimulationParams;
 @group(0) @binding(5)
 var<storage, read> config: RenderConfig;
+@group(0) @binding(6)
+var<storage, read> phases: array<Phase>;
+
+struct Phase {
+    phase: f32,
+    max_stretch: f32,
+}
 
 struct RenderConfig {
     mode: u32,
@@ -28,6 +35,7 @@ const VELOCITY: u32 = 2;
 const CDF_NORMALS: u32 = 3;
 const CDF_DISTANCES: u32 = 4;
 const CDF_SIGNS: u32 = 5;
+const PHASE: u32 = 6;
 
 
 struct InstanceData {
@@ -78,16 +86,19 @@ fn main(
                 instances[particle_id].color = vec4(abs(d), 0.0, 0.0, color.w);
             }
         } else if config.mode == CDF_SIGNS {
-             let d = particles_dyn[particle_id].cdf.affinity;
-             let a = (d >> 16) & (d & 0x0000ffff);
-             if d == 0 {
-                 instances[particle_id].color = vec4(0.0, 0.0, 0.0, color.w);
-             } else if a == 0 {
-                 instances[particle_id].color = vec4(0.0, 1.0, 0.0, color.w);
-             } else {
-                 instances[particle_id].color = vec4(1.0, 0.0, 0.0, color.w);
-             }
-         }
+            let d = particles_dyn[particle_id].cdf.affinity;
+            let a = (d >> 16) & (d & 0x0000ffff);
+            if d == 0 {
+                instances[particle_id].color = vec4(0.0, 0.0, 0.0, color.w);
+            } else if a == 0 {
+                instances[particle_id].color = vec4(0.0, 1.0, 0.0, color.w);
+            } else {
+                instances[particle_id].color = vec4(1.0, 0.0, 0.0, color.w);
+            }
+        } else if config.mode == PHASE {
+            let phase = phases[particle_id].phase;
+            instances[particle_id].color = vec4(vec3(mix(0.1, 1.0, phase)), color.w);
+        }
     }
 }
 

--- a/src_testbed/step.rs
+++ b/src_testbed/step.rs
@@ -153,6 +153,7 @@ pub fn step_simulation_legacy(
             &mut queue,
             &app_state.gpu_render_config,
             &physics.data.particles,
+            &physics.data.models,
             &physics.data.rigid_particles,
             &physics.data.grid,
             &physics.data.sim_params,

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -39,7 +39,7 @@ pub fn update_ui(
         egui::ComboBox::from_label("render mode")
             .selected_text(RenderMode::from_u32(app_state.render_config.mode).text())
             .show_ui(ui, |ui| {
-                for i in 0..6 {
+                for i in 0..7 {
                     changed = ui
                         .selectable_value(
                             &mut app_state.render_config.mode,


### PR DESCRIPTION
This PR does a couple of things:
* Allows displaying the phase in the rendering.
  * In order to do this, I needed to make the particle phase struct available outside of the `particle_update.wgsl` file, so I moved it to both `particle2d.wgsl` and `particle3d.wgsl`; I don't think there's really much of a better place to put that.
* Adds ghost particle advection.
  * Advection does not handle rigid colliders properly right now.
* Made most of the storage tensors COPY_SRC. That's necessary for interfacing with other things and I don't see much of a reason for them not to be.
* Made an `init_testebed_with_settings` function that can take in some parameters.